### PR TITLE
Merge upstream code from geerlingguy.homebrew repository

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 skip_list:
-  - '208'
-  - '106'
+  - 'yaml'
+  - 'risky-file-permissions'
+  - 'role-name'

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,6 +12,7 @@ onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
+  - bug
   - pinned
   - security
   - planned

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint
+        run: pip3 install yamllint ansible ansible-lint
 
       - name: Lint code.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,11 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible ansible-lint
+        run: pip3 install yamllint
 
       - name: Lint code.
         run: |
           yamllint .
-          ansible-lint
 
   integration:
     name: Integration

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available variables are listed below, along with default values (see [`defaults/
 
 The GitHub repository for Homebrew core.
 
-    homebrew_prefix: /usr/local
+    homebrew_prefix: "{{ (ansible_machine == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
     homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
 
 The path where Homebrew will be installed (`homebrew_prefix` is the parent directory). It is recommended you stick to the default, otherwise Homebrew might have some weird issues. If you change this variable, you should also manually create a symlink back to /usr/local so things work as Homebrew expects.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Ansible Role: Homebrew
+# Ansible Role: Homebrew (MOVED)
+
+**MOVED**: This role has been moved into the `geerlingguy.mac` collection. Please see [this issue](https://github.com/geerlingguy/ansible-role-homebrew/issues/166) for a migration guide and more information.
 
 [![MIT licensed][badge-license]][link-license]
 [![Galaxy Role][badge-role]][link-galaxy]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 homebrew_repo: https://github.com/Homebrew/brew
 
-homebrew_prefix: /usr/local
+homebrew_prefix: "{{ (ansible_machine == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
 homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
 homebrew_brew_bin_path: "{{ homebrew_prefix }}/bin"
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,6 +10,7 @@
 
     homebrew_cask_apps:
       - firefox  # from hombrew/cask
+      - google-chrome  # from hombrew/cask
 
     homebrew_taps:
       - homebrew/core


### PR DESCRIPTION
Merge upstream code from geerlingguy.homebrew repository. This is a backup option if we are not able to use yugabyte fork of geerlingguy.mac repository in setup_workstation.sh script (See: https://github.com/yugabyte/internal-devops/pull/267#issuecomment-1007180729).