### PR TITLE
Fix parent directory permission check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,22 +5,21 @@
     homebrew_group: '{{ homebrew_group | default(ansible_user_gid) }}'
 
 # Homebrew setup prerequisites.
-- name: Ensure Homebrew parent directory has correct permissions (MacOS >= 12.0).
+- name: Ensure Homebrew parent directory has correct permissions (arm64).
   file:
     path: "{{ homebrew_prefix }}"
     owner: "{{ homebrew_user }}"
     state: directory
   become: true
-  when: "ansible_distribution_version is version('12.0', '>=')"
+  when: ansible_machine == "arm64"
 
-- name: Ensure Homebrew parent directory has correct permissions (12.0 > MacOS >= 10.13).
+- name: Ensure Homebrew parent directory has correct permissions (MacOS >= 10.13).
   file:
     path: "{{ homebrew_prefix }}"
     owner: root
     state: directory
   become: true
-  when: ansible_distribution_version is version('10.13', '>=') and
-        ansible_distribution_version is version('12.0', '<')
+  when: ansible_distribution_version is version('10.13', '>=') and ansible_machine == "x86_64"
 
 - name: Ensure Homebrew parent directory has correct permissions (MacOS < 10.13).
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,8 +19,8 @@
     owner: root
     state: directory
   become: true
-  when: "ansible_distribution_version is version('10.13', '>=')" and
-        "ansible_distribution_version is version('12.0', '<')"
+  when: ansible_distribution_version is version('10.13', '>=') and
+        ansible_distribution_version is version('12.0', '<')
 
 - name: Ensure Homebrew parent directory has correct permissions (MacOS < 10.13).
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,13 +5,22 @@
     homebrew_group: '{{ homebrew_group | default(ansible_user_gid) }}'
 
 # Homebrew setup prerequisites.
-- name: Ensure Homebrew parent directory has correct permissions (MacOS >= 10.13).
+- name: Ensure Homebrew parent directory has correct permissions (MacOS >= 12.0).
+  file:
+    path: "{{ homebrew_prefix }}"
+    owner: "{{ homebrew_user }}"
+    state: directory
+  become: true
+  when: "ansible_distribution_version is version('12.0', '>=')"
+
+- name: Ensure Homebrew parent directory has correct permissions (12.0 > MacOS >= 10.13).
   file:
     path: "{{ homebrew_prefix }}"
     owner: root
     state: directory
   become: true
-  when: "ansible_distribution_version is version('10.13', '>=')"
+  when: "ansible_distribution_version is version('10.13', '>=')" and
+        "ansible_distribution_version is version('12.0', '<')"
 
 - name: Ensure Homebrew parent directory has correct permissions (MacOS < 10.13).
   file:


### PR DESCRIPTION
brew works if /usr/local is owned by root, but when working in /opt/homebrew it insists it needs to be owned by the brew user, not root.