### PR TITLE
Update main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,7 @@ homebrew_uninstalled_packages: []
 
 homebrew_upgrade_all_packages: false
 
-homebrew_taps:
-  - homebrew/core
+homebrew_taps: []
 
 homebrew_cask_apps: []
 


### PR DESCRIPTION
Brew errors now when you try to tap the core cask b/c it shouldn't be necessary :roll_eyes: 

```
$ brew tap homebrew/core
Error: Tapping homebrew/core is no longer typically necessary.
Add --force if you are sure you need it done.
```